### PR TITLE
Refactor pinyin matching

### DIFF
--- a/google/docs/pinyinScript.txt
+++ b/google/docs/pinyinScript.txt
@@ -1,3 +1,12 @@
+/**
+ * @OnlyCurrentDoc
+ *
+ * The above comment directs Apps Script to limit the scope of file access for
+ * this add-on to the current doc. The authorization request message presented
+ * to users will reflect this limited scope.
+ */
+
+/** Add pinyin options to document menu. */
 function onOpen() {
   var ui = DocumentApp.getUi();
   ui.createMenu('Pinyin')
@@ -6,426 +15,463 @@ function onOpen() {
       .addToUi();
 }
 
-function mdzs() {
-  var body = DocumentApp.getActiveDocument().getBody();
-  
-  /**
-   **
-   **Yunmeng Jiang Sect and related stuff
-   **
-  **/
-  //Yunmeng Jiang Sect (云梦江氏, Yúnmèng Jiāng Shì)
-  body.replaceText("(Y|y)un(M|m)eng.?(J|j)iang", "Yúnmèng Jiāng");
-  body.replaceText("(Y|y)un(M|m)eng", "Yúnmèng");
-  
-  body.replaceText("(S|s)ect (L|l)eader (J|j)iang", "Sect Leader Jiāng");
-  
-  //Wei Ying (魏婴 Wèi Yīng), courtesy name Wei Wuxian (魏无羡, Wèi Wúxiàn), and his title Yiling Patriarch (夷陵老祖, Yílíng Lǎozǔ)
-  body.replaceText("(W|w)ei.?(Y|y)ing", "Wèi Yīng");
-  body.replaceText("(W|w)ei.?(W|w)u(X|x)ian", "Wèi Wúxiàn");
-  body.replaceText("(W|w)ei-", "Wèi-");
-  body.replaceText("(Y|y)oung (M|m)aster (W|w)ei", "Young Master Wèi");
-  body.replaceText("(Y|y)i(L|l)ing.?(P|p)atriarch", "Yílíng Patriarch");
-  body.replaceText("(Y|y)i(L|l)ing.?(L|l)aozu", "Yílíng Lǎozǔ");
-  body.replaceText("(Y|y)i(L|l)ing", "Yílíng");
-    
-  //Jiang Cheng (江澄 Jiāng Chéng), courtesy name Jiang Wanyin (江晚吟 Jiāng Wǎnyín), and his title Sandu Shengshou (三毒圣手 Sāndú shèngshǒu).
-  body.replaceText("(J|j)iang.?(C|c)heng", "Jiāng Chéng");
-  body.replaceText("(J|j)iang.?(W|w)an(Y|y)in", "Jiāng Wǎnyín");
-  body.replaceText("(S|s)an(D|d)u.?(S|s)heng(S|s)hou", "Sāndú Shèngshǒu");
-  body.replaceText("(S|s)an(D|d)u.? ", "Sāndú.? ");
-  
-  //Yu Ziyuan (虞紫鸢, Yú Zǐyuān) and title Madam Yu (虞夫人, Yú fūrén) and the Violet Spider (紫蜘蛛, Zǐ Zhīzhū).
-  body.replaceText("(Y|y)u.?(Z|z)i(Y|y)uan", "Yú Zǐyuān");
-  body.replaceText("(Z|z)i(Y|y)uan", "Zǐyuān");
-  body.replaceText("(Y|y)u.?(F|f)uren", "Yú fūrén");
-  body.replaceText("(M|m)adame.?(Y|y)u", "Madame Yú");
-  body.replaceText("(Z|z)i.?(Z|z)hi(Z|z)hu", "Zǐ Zhīzhū");
-  
-  //Jiang Fengmian (江枫眠, Jiāng Fēngmián)
-  body.replaceText("(J|j)iang.?(F|f)eng(M|m)ian", "Jiāng Fēngmián");
-  
-  //Jiang Yanli (江厌离, Jiāng Yànlí)
-  body.replaceText("(J|j)iang (Y|y)an(L|l)i", "Jiāng Yànlí");
-  body.replaceText("(Y|y)anL(L|l)i", "Yànlí");
-  
-  //Zidian (紫电, Zǐdiàn)
-  body.replaceText("(Z|z)i(D|d)ian", "Zǐdiàn");
-  
-  // Chenqing  陈情 Chén qíng
-  body.replaceText("(C|c)hen(Q|q)ing", "Chénqíng");
-  
-  //Suibian 随便 Suíbiàn
-  body.replaceText("(S|s)ui(B|b)ian", "Suíbiàn");
-  
-  body.replaceText("(J|j)iang", "Jiāng");
-  
-  
-  /**
-   **
-   **Lanling Jin Sect
-   **
-  **/
-  //Lanling Jin Sect (兰陵金氏, Lánlíng Jīn Shì)
-  body.replaceText("(L|l)an(L|l)ing.?(J|j)in.?(S|s)hi", "Lánlíng Jīn Shì");
-  body.replaceText("(L|l)an(L|l)ing.?(J|j)in", "Lánlíng Jīn");
-  body.replaceText("(L|l)an(L|l)ing", "Lánlíng");
-  
-  //Jin Zixuan (金子轩, Jīn Zixuān)
-  body.replaceText("(J|j)in.?(Z|z)i(X|x)uan", "Jīn Zixuān");
-  
-  //Jin Ling (金凌, Jīn Líng), courtesy name Jin Rulan (金如兰, Jīn Rúlán)
-  body.replaceText("(J|j)in.?(L|l)ing", "Jīn Líng");
-  body.replaceText("(J|j)in.?(R|r)u(L|l)an", "Jīn Rúlán");
-  
-  //Jin Guangshan (金光善, Jīn Guāngshàn)
-  body.replaceText("(J|j)in.?(G|g)uang(S|s)han", "Jīn Guāngshàn");
-  
-  //Jin Guangyao (金光瑶, Jīn Guāngyáo), birth name Meng Yao (孟瑶, Mèng Yáo)
-  body.replaceText("(J|j)in.?(G|g)uang(Y|y)ao", "Jīn Guāngyáo");
-  body.replaceText("(M|m)eng.?(Y|y)ao", "Mèng Yáo");
-  
-  //Mo Xuanyu (莫玄羽, Mò Xuányǔ) 
-  body.replaceText("(M|m)o.?(X|x)uan(Y|y)u", "Mò Xuányǔ");
-  body.replaceText("(S|s)enior (M|m)o", "Senior Mò");
-  
-  //Mian Mian (Chinese: 绵绵; Miánmián)
-  body.replaceText("(M|m)ian.?(M|m)ian", "Miánmián");
-  
-  //Carp Tower (金鳞台, Jīnlín Tái; also: Koi Tower, Jinlin Tower
-  body.replaceText("(J|j)in(L|l)in.?(T|t)ower", "Jīnlín Tower");
-  
-  
-  /**
-   **
-   **Gusu Lan Sect
-   **
-  **/
-  //Gusu Lan Sect (姑苏蓝氏, Gūsū Lán Shì), Gusu (姑苏, Gūsū
-  body.replaceText("(G|g)u(S|s)u.?(L|l)an", "Gūsū Lán");
-  body.replaceText(" Gusu ", " Gūsū ");
-  
-  //Lan Zhan (蓝湛 Lán Zhàn), courtesy name Lan Wangji (蓝忘机, Lán Wàngjī) , and title Hanguang-Jun (含光君, Hánguāng-jūn),
-  body.replaceText("(L|l)an.?(Z|z)han", "Lán Zhàn");
-  body.replaceText("Zhan-", "Zhàn-");
-  body.replaceText("(L|l)an.?(W|w)ang.?(J|j)i", "Lán Wàngjī");
-  body.replaceText("(W|w)ang(J|j)i", "Wàngjī");
-  body.replaceText("(H|h)an(G|g)uang.?(J|j)un", "Hánguāng-jūn");
-  body.replaceText("(M|m)aster (L|l)an", "Master Lán");
-  
-  //Lan Qiren (蓝启仁, Lán Qǐrén) 
-  body.replaceText("(L|l)an.?(Q|q)ui(R|r)en", "Lán Qǐrén");
-  
-  //Lan Huan (蓝涣, Lán Huàn), courtesy name Lan Xichen (蓝曦臣, Xīchén) and title Zewu-Jun (泽芜君, Zéwú-jūn)
-  body.replaceText("(L|l)an.?(H|h)uan", "Lán Huàn");
-  body.replaceText("(L|l)an.?(X|x)i(C|c)hen", "Lán Xīchén");
-  body.replaceText("(z|Z)e(W|w)u.?(J|j)un", "Zéwú-jūn");
- 
-  
-  //Lan Yuan (蓝愿, Lán yuàn) courtesy name Lan Sizhui (思追, Lán Sīzhuī) and born Wen Yuan (温苑, Wēn yuàn)
-  body.replaceText("(L|l)an.?(Y|y)uan", "Lán Yuàn");
-  body.replaceText("A-Yuan", "A-Yuàn");
-  body.replaceText("(L|l)an.?(S|s)i(Z|z)hui", "Lán Sīzhuī");
-  body.replaceText("(S|s)i(Z|z)hui", "Sīzhuī");
-  body.replaceText("(W|w)en.?(Y|y)uan", "Wēn Yuàn");
-  
-  //Lan Jingyi (蓝景仪, Lán Jǐngyí) 
-  body.replaceText("(L|l)an.?(J|j)ing(Y|y)i", "Lán Jǐngyí");
-  body.replaceText("(J|j)ing(Y|y)i?", "Jǐngyí");
-  
-  
-  //Caiyi Town (彩衣城, Cǎiyī Chéng) 
-  body.replaceText("(C|c)ai(Y|y)i.?(T|t)own", "Cǎiyī Town");
-  body.replaceText("(C|c)ai(Y|y)i.?(C|c)heng", "Cǎiyī Chéng");
-  
-  //Jìngshì (静室, jìng shì)
-  body.replaceText("(J|j)ing(S|s)hi", "Jìngshì");
-  
-  //Bichen (避尘, Bìchén)
-  body.replaceText("(B|b)i(C|c)hen", "Bìchén");
-  
-  
-  
-  
-  /**
-   **
-   **Qinghe Nie Sect
-   **
-  **/
-  //Qinghe Nie Sect (清河聂氏, Qīnghé Niè Shì) 
-  body.replaceText("(Q|q)ing(H|h)e.?(N|n)ie.?(S|s)hi", "Qīnghé Niè Shì");
-  body.replaceText("(Q|q)ing(H|h)e.?(N|n)ie", "Qīnghé Niè");
-  body.replaceText("(Q|q)ing(H|h)e", "Qīnghé");
-  
-  //Nie Huaisang (聂怀桑, Niè Huáisāng) 
-  body.replaceText("(N|n)ie.?(H|h)uai(S|s)ang", "Niè Huáisāng");
-  
-  //Nie Mingjue (聂明玦, Niè Míngjué) 
-  body.replaceText("(N|n)ie.?(M|m)ing(J|j)ue", "Niè Míngjué");
-   
-  
-  
-  
-  /**
-   **
-   **Qishan Wen Sect
-   **
-  **/
-  //Qishan Wen Sect (岐山温氏, Qíshān Wēn Shì)
-  body.replaceText("(Q|q)i(S|s)han.?(W|w)en.?(S|s)hi", "Qíshān Wēn Shì");
-  body.replaceText("(Q|q)i(S|s)han.?(W|w)en", "Qíshān Wēn");
-  
-  //Wen Ning (温宁, Wēn Níng), courtesy name Qionglin (温琼林, Qiónglín)  Known as the Ghost General (鬼将军, Guǐ jiāngjūn)
-  body.replaceText("(W|w)en.?(N|n)ing", "Wēn Níng");
-  body.replaceText("(W|w)en.?(Q|q)iong(L|l)in", "Wēn Qiónglín");
-  body.replaceText("(G|g)ui.?(J|j)iang(J|j)un", "Guǐ jiāngjūn");
-  
-  //Wen Qing (温情, Wēn Qíng)
-  body.replaceText("(W|w)en.?(Q|q)ing", "Wēn Qíng");
-  
-  //Wen Ruohan (温若寒, Wēn Ruòhán)
-  body.replaceText("(W|w)en.?(R|r)uo(H|h)an", "Wēn RuòHán");
-  
-  //Wen Chao (温晁, Wēn Cháo)
-  body.replaceText("(W|w)en.?(C|c)hao", "Wēn Cháo");
-  
-  //Wen Xu (温旭, Wēn Xù)
-  body.replaceText("(W|w)en.?(X|x)u", "Wēn Xù");
-  
-  
-  //Wen Zhuliu Wēn Zhúliú 温逐流
-  body.replaceText("(W|w)en.?(Z|z)hu.?(L|l)iu", "Wēn Zhúliú")
-  
-  
-  
-  /**
-   **
-   **misc people
-   **
-  **/
-  //Song Lan (宋岚, Sòng Lán), courtesy name Song Zichen (宋子琛)
-  body.replaceText("(S|s)ong.?(L|l)an", "Sòng Lán");
-  body.replaceText("(S|s)ong.?(Z|z)i(C|c)hen", "Sòng Zichēn");
-  
-  //Fuxue (拂雪, Fúxuě)
-  body.replaceText("(F|f)u(X|x)ue", "Fúxuě");
-  
-  //Xiao Xingchen (晓星尘, Xiǎo Xīngchén) 
-  body.replaceText("(X|x)iao.?(X|x)ing(C|c)hen", "Xiǎo Xīngchén");
-  
-  //Shuanghua (霜华, Shuānghuá)
-  body.replaceText("(S|s)huang(H|h)ua", "Shuānghuá");
-  
-  //Xue Yang (薛洋, Xuē Yáng) 
-  body.replaceText("(W|w)en.?(X|x)u", "Xuē Yáng");
-  
-  //Baoshan Sanren (抱山散人, Bàoshān sànrén)
-  body.replaceText("(B|b)ao(S|s)han.?(S|s)an(R|r)en", "Bàoshān Sànrén");
-  
-  //Cangse Sanren (藏色散人, Cángsè Sànrén)
-  body.replaceText("(C|c)ang(S|s)e.?(S|s)an(R|r)en", "Cángsè Sànrén");
-  
- //Ouyang Zizhen (欧阳子真 Ōuyáng Zizhēn 
-  body.replaceText("(O|o)u(Y|y)ang.?(Z|z)i(Z|z)hen", "Ōuyáng Zizhēn");
-  body.replaceText("(C|c)ang(S|s)e.?(S|s)an(R|r)en", "Cángsè Sànrén");
-  
-  
-  
-  
-  /**
-   **
-   **misc other
-   **
-  **/
-  //gongzi (公子, gōngzī)
-  body.replaceText("(G|g)ong(Z|z)i", "gōngzī");
-  
-  //guqin ( Chinese: 古琴;  pinyin: gǔqín)
-  body.replaceText("(G|g)u(Q|q)in", "gǔqín");
-  
-  //Yi City (Chinese: 义城; pinyin: Yì chéng)
-  body.replaceText("(Y|y)i.?(C|c)ity", "Yì City");
-  body.replaceText("(Y|y)i.?(C|c)heng", "Yì Chéng");
-  
-  //Dafan Mountain (大梵山, Dà fàn shān)
-  body.replaceText("(D|d)a.?(F|f)an.?(M|m)ountain", "Dàfàn Mountain");
-  body.replaceText("(D|d)a.?(F|f)an.?(S|s)han", "Dàfàn shān");
-  
-  //ge (Chinese: 哥; pinyin: 
-  body.replaceText("-(G|g)e", "-gē");
-  
-  //Gege (Chinese: 哥哥; pinyin: Gégé
-  body.replaceText("-(G|g)e(G|g)e", "-gēge");
-  
-  //xiong (兄 Xiōng)
-  body.replaceText("-(X|x)iong", "-xiōng");
-  
-  //Jiejie (Chinese: 姐姐, Jiějiě)
-  body.replaceText("(J|j)ie(J|j)ie", "jiějiě");
-  //Jie (Chinese: 姐, Jiě)
-  body.replaceText("-(J|j)ie", "jiě");
-    
-  //shī jiě 师姐 
-  body.replaceText("(S|s)hi(J|j)ie", "shījiě");
+/**
+ * Returns a regex string to match a sequence of words, allowing an optional
+ * dash (-) or space ( ) between each word. The beginning and end of the
+ * matching sequence must be at a word boundary.
+ */
+function wordsMatchRegex(words) {
+  return '\\b(' + words.join('( |-)?') + ')\\b';
 }
 
+/**
+ * Returns a regex string to match a sequence of words, case-insensitively. See
+ * wordsMatchRegex for more info.
+ */
+function wordsMatchIgnoreCaseRegex(words) {
+  return '((?i)(' + wordsMatchRegex(words) + '))';
+}
 
+/**
+ * Hard-coded MDZS pinyin replacement rules.
+ */
+function mdzsReplacements() {
+  // For each line 'some text here|fancy replacement', replaces all instances of
+  // 'some text here' in the doc with 'fancy replacement'.
+  // Notes:
+  //  * capitalization on the left side is ignored
+  //  * any spaces on the left side that are between words will matching things
+  //    with
+  //    (a) no space there (b) a dash there or (c) a space there. Examples:
+  //      - 'hanguang jun|Hánguāng-jūn' means any of 'hanguang jun',
+  //        'hanguangjun', or 'hanguang-jun' will be replaced with
+  //        'Hánguāng-jūn'
+  //      - 'wen ke xing|Wēn Kèxíng' means that all of 'Wen KeXing', 'Wen Ke
+  //        Xing', and 'wen kexing' will be replaced with 'Wēn Kèxíng'
+  //  * any spaces on the left or right that are before all words or after all
+  //    words will be ignored
+  //  * partial-word matches will be ignored (e.g., if 'lan' is part of 'plan'
+  //    or 'land' it will not be replaced; if 'lan sect' is part of 'plan sect'
+  //    it will not be replaced)
+  //  * lines with only spaces on them, or that start with #, will be ignored.
+  return `
+      # Yunmeng Jiang Sect and related stuff
+      ## Wei Ying (魏婴 Wèi Yīng), courtesy name Wei Wuxian (魏无羡, Wèi Wúxiàn) and his title Yiling Patriarch (夷陵老祖, Yílíng Lǎozǔ)
+      wei ying|Wèi Yīng
+      wei wuxian|Wèi Wúxiàn
+      wy|Wèi Yīng
+      wwx|Wèi Wúxiàn
+      a xian|A-Xiàn
+      young master wei|Young Master Wèi
+      yiling patriarch|Yílíng Patriarch
+      yiling laozu|Yílíng Lǎozǔ
+      yiling|Yílíng
+      laozu|Lǎozǔ
+      wei|Wèi
+      wuxian|Wúxiàn
+      ## Jiang Cheng (江澄 Jiāng Chéng), courtesy name Jiang Wanyin (江晚吟 Jiāng Wǎnyín), and his title Sandu Shengshou (三毒圣手 Sāndú shèngshǒu)
+      jiang cheng|Jiāng Chéng
+      a cheng|A-Chéng
+      sandu shengshou|Sāndú Shèngshǒu
+      sandu|Sāndú
+      shengshou|Shèngshǒu
+      wanyin|Wǎnyín
+      ## Yu Ziyuan (虞紫鸢, Yú Zǐyuān) and title Madam Yu (虞夫人, Yú fūrén) and the Violet Spider (紫蜘蛛, Zǐ Zhīzhū).
+      yu ziyuan|Yú Zǐyuān
+      yu furen|Yú fūrén
+      madame yu|Madame Yú
+      zi zhizhu|Zǐ Zhīzhū
+      ziyuan|Zǐyuān
+      ## Jiang Fengmian (江枫眠, Jiāng Fēngmián)
+      jiang fengmian|Jiāng Fēngmián
+      fengmian|Fēngmián
+      ## Jiang Yanli (江厌离, Jiāng Yànlí)
+      jiang yanli|Jiāng Yànlí
+      yanli|Yànlí
+      ## hmmmmmm technically this could also be the unit "a li" (~.5 km), so maybe remove
+      a li|A-Lí
+      ## Zidian (紫电, Zǐdiàn), Chenqing  陈情 Chén qíng, Suibian 随便 Suíbiàn
+      zidian|Zǐdiàn
+      chenqing|Chénqíng
+      suibian|Suíbiàn
+      ## Yunmeng Jiang Sect (云梦江氏, Yúnmèng Jiāng Shì)
+      sect leader jiang|Sect Leader Jiāng
+      yunmeng jiang shi|Yúnmèng Jiāng Shì
+      yunmeng|Yúnmèng
+      jiang|Jiāng
+      
+      # Lanling Jin Sect
+      ## Jin Zixuan (金子轩, Jīn Zixuān)
+      jin zixuan|Jīn Zixuān
+      zixuan|Zixuān
+      ## Jin Ling (金凌, Jīn Líng), courtesy name Jin Rulan (金如兰, Jīn Rúlán)
+      jin ling|Jīn Líng
+      a ling|A-Líng
+      jin rulan|Jīn Rúlán
+      rulan|Rúlán
+      ## Jin Guangshan (金光善, Jīn Guāngshàn)
+      jin guangshan|Jīn Guāngshàn
+      ## Jin Guangyao (金光瑶, Jīn Guāngyáo), birth name Meng Yao (孟瑶, Mèng Yáo)
+      jin guangyao|Jīn Guāngyáo
+      guangyao|Guāngyáo
+      meng yao|Mèng Yáo
+      a yao|A-Yáo
+      ## Mo Xuanyu (莫玄羽, Mò Xuányǔ)
+      mo xuanyu|Mò Xuányǔ
+      xuanyu|Xuányǔ
+      senior mo|Senior Mò
+      ## Mian Mian (Chinese: 绵绵; Miánmián)
+      mian mian|Miánmián
+      ## Carp Tower (金鳞台, Jīnlín Tái; also: Koi Tower, Jinlin Tower)
+      jin lin tower|Jīnlín Tower
+      jin lin tai|Jīnlín Tái
+      ## Lanling Jin Sect (兰陵金氏, Lánlíng Jīn Shì)
+      langling jin shi|Lánlíng Jīn Shì
+      langling jin|Lánlíng Jīn
+      lanling|Lánlíng
+      jin|Jīn
+      
+      # Gusu Lan Sect
+      ## Lan Zhan (蓝湛 Lán Zhàn), courtesy name Lan Wangji (蓝忘机, Lán Wàngjī) , and title Hanguang-Jun (含光君, Hánguāng-jūn),
+      lan zhan|Lán Zhàn
+      zhan|Zhàn
+      lan wang ji|Lán Wàngjī
+      lwj|Lán Wàngjī
+      wangji|Wàngjī
+      hanguang jun|Hánguāng-jūn
+      master lan|Master Lán
+      ## Lan Qiren (蓝启仁, Lán Qǐrén)
+      lan qiren|Lán Qǐrén
+      qiren|Qǐrén
+      ## Lan Huan (蓝涣, Lán Huàn), courtesy name Lan Xichen (蓝曦臣, Xīchén) and title Zewu-Jun (泽芜君, Zéwú-jūn)
+      lan huan|Lán Huàn
+      lan xichen|Lán Xīchén
+      zewu jun|Zéwú-jūn
+      ## Lan Yuan (蓝愿, Lán yuàn) courtesy name Lan Sizhui (思追, Lán Sīzhuī) and born Wen Yuan (温苑, Wēn yuàn)
+      lan yuan|Lán Yuàn
+      a yuan|A-Yuàn
+      lan sizhui|Lán Sīzhuī
+      sizhui|Sīzhuī
+      wen yuan|Wēn Yuàn
+      ## Lan Jingyi (蓝景仪, Lán Jǐngyí)
+      lan jingyi|Lán Jǐngyí
+      jingyi|Jǐngyí
+      ## Caiyi Town (彩衣城, Cǎiyī Chéng)
+      caiyi town|Cǎiyī Town
+      caiyi cheng|Cǎiyī Chéng
+      ## Jìngshì (静室, jìng shì)
+      jingshi|Jìngshì
+      ## Bichen (避尘, Bìchén)
+      bichen|Bìchén
+      ## Gusu Lan Sect (姑苏蓝氏, Gūsū Lán Shì), Gusu (姑苏, Gūsū)
+      gusu lan shi|Gūsū Lán Shì
+      gusu lan|Gūsū Lán
+      # don't match lan|Lán because we might miss Song Lan
+      gusu|Gūsū
+      
+      # Qinghe Nie Sect
+      ## Nie Huaisang (聂怀桑, Niè Huáisāng)
+      nie huaisang|Niè Huáisāng
+      huaisang|Huáisāng
+      ## Nie Mingjue (聂明玦, Niè Míngjué)
+      nie mingjue|Niè Míngjué
+      mingjue|Míngjué
+      ## Qinghe Nie Sect (清河聂氏, Qīnghé Niè Shì)
+      qinghe nie shi|Qīnghé Niè Shì
+      qinghe nie|Qīnghé Niè
+      qinghe|Qīnghé
+      nie|Niè
+      
+      # Qishan Wen Sect
+      ## Wen Ning (温宁, Wēn Níng), courtesy name Qionglin (温琼林, Qiónglín)  Known as the Ghost General (鬼将军, Guǐ jiāngjūn)
+      Wen Ning|Wēn Níng
+      Wen Qionglin|Wēn Qiónglín
+      Qionglin|Qiónglín
+      Gui Jiangjun|Guǐ jiāngjūn
+      ## Wen Qing (温情, Wēn Qíng)
+      Wen Qing|Wēn Qíng
+      ## Wen Ruohan (温若寒, Wēn Ruòhán)
+      Wen Ruohan|Wēn RuòHán
+      ## Wen Chao (温晁, Wēn Cháo)
+      Wen Chao|Wēn Cháo
+      ## Wen Xu (温旭, Wēn Xù)
+      Wen Xu|Wēn Xù
+      ## Wen Zhuliu (Wēn Zhúliú 温逐流)
+      Wen Zhu Liu|Wēn Zhúliú
+      Zhu Liu|Zhúliú
+      ## Qishan Wen Sect (岐山温氏, Qíshān Wēn Shì)
+      Qishan Wen Shi|Qíshān Wēn Shì
+      Qishan Wen|Qíshān Wēn
+      Qishan|Qíshān
+      Da Fan Wen|Dàfàn Wēn
+      Wen|Wēn
+      
+      # misc people
+      ## Song Lan (宋岚, Sòng Lán), courtesy name Song Zichen (宋子琛)
+      Song Lan|Sòng Lán
+      Song Zichen|Sòng Zichēn
+      Zichen|Zichēn
+      ## Fuxue (拂雪, Fúxuě)
+      Fuxue|Fúxuě
+      ## Xiao Xingchen (晓星尘, Xiǎo Xīngchén)
+      Xiao Xingchen|Xiǎo Xīngchén
+      Xingchen|Xīngchén
+      ## Shuanghua (霜华, Shuānghuá)
+      Shuanghua|Shuānghuá
+      ## Xue Yang (薛洋, Xuē Yáng)
+      Xue Yang|Xuē Yáng
+      ## Baoshan Sanren (抱山散人, Bàoshān sànrén)
+      Baoshan Sanren|Bàoshān Sànrén
+      ## Cangse Sanren (藏色散人, Cángsè Sànrén)
+      Cangse Sanren|Cángsè Sànrén
+      Zangse Sanren|Zángsè Sànrén
+      ## Ouyang Zizhen (欧阳子真 Ōuyáng Zizhēn)
+      Ouyang Zizhen|Ōuyáng Zizhēn
+      
+      # misc other
+      ## gongzi (公子, gōngzī)
+      Gongzi|gōngzī
+      ## guqin ( Chinese: 古琴;  pinyin: gǔqín)
+      Guqin|gǔqín
+      ## Yi City (Chinese: 义城; pinyin: Yì chéng)
+      Yi City|Yì City
+      Yi Cheng|Yì Chéng
+      ## Dafan Mountain (大梵山, Dà fàn shān)
+      Da Fan Mountain|Dàfàn Mountain
+      Da Fan Shan|Dàfàn shān
+      ## 大哥 dà gē
+      da ge|dàgē
+      ## ge (Chinese: 哥; pinyin: gē)
+      -Ge|-gē
+      ## Gege (Chinese: 哥哥; pinyin: Gégé)
+      Gege|gēge
+      ## xiōngzhǎng 兄长
+      xiong zhang|Xiōngzhǎng
+      ## xiong (兄 Xiōng)
+      -Xiong|-xiōng
+      ## Jiejie (Chinese: 姐姐, Jiějiě)
+      Jiejie|jiějiě
+      ## shī jiě 师姐
+      Shijie|shījiě
+      ## Jie (Chinese: 姐, Jiě)
+      -Jie|-jiě
+  
+      # attempt to match lan|Lán at the end, after conflict with Song Lan doesn't matter
+      lan|Lán
+      `;
+}
+
+/**
+ * Hard-coded Guardian pinyin replacement rules.
+ */
+function guardianReplacements() {
+  // For each line 'some text here|fancy replacement', replaces all instances of
+  // 'some text here' in the doc with 'fancy replacement'.
+  // Notes:
+  //  * capitalization on the left side is ignored
+  //  * any spaces on the left side that are between words will matching things
+  //    with
+  //    (a) no space there (b) a dash there or (c) a space there. Examples:
+  //      - 'hanguang jun|Hánguāng-jūn' means any of 'hanguang jun',
+  //        'hanguangjun', or 'hanguang-jun' will be replaced with
+  //        'Hánguāng-jūn'
+  //      - 'wen ke xing|Wēn Kèxíng' means that all of 'Wen KeXing', 'Wen Ke
+  //        Xing', and 'wen kexing' will be replaced with 'Wēn Kèxíng'
+  //  * any spaces on the left or right that are before all words or after all
+  //    words will be ignored
+  //  * partial-word matches will be ignored (e.g., if 'lan' is part of 'plan'
+  //    or 'land' it will not be replaced; if 'lan sect' is part of 'plan sect'
+  //    it will not be replaced)
+  //  * lines with only spaces on them, or that start with #, will be ignored.
+  return `
+      # guardian
+      ## Zhao Yunlan (赵云澜 / 趙云瀾, Zhào Yúnlán)
+      Chief Zhao|Chief Zhào
+      Zhao Yun Lan|Zhào Yúnlán
+      Yunlan|Yúnlán
+      ## in the past: Kunlan Kūnlún | 昆仑
+      Kunlun|Kūnlún
+      ## Shen Wei (沈巍	Shěn Wēi) or Xiao Wei Xiǎo Wēi 小巍
+      Shen Wei|Shěn Wēi
+      Professor Shen|Professor Shěn
+      Hei Pao Shi|Hēi Páo Shǐ
+      Xiao Wei|Xiǎo Wēi")
+      ## Zhao Xinci (赵心慈	Zhào Xīncí)
+      Zhao Xin Ci|Zhào Xīncí
+      ## Guo Ying 郭英 Guō Yīng
+      Guo Ying|Guō Yīng
+      ## Guo Changcheng 郭长城 Guō Chángchéng
+      Guo Chang Cheng|Guō Chángchéng
+      ## Zhu Hong 祝红 Zhù hóng
+      Zhu Hong|Zhù Hóng
+      ## Da Qing 大庆 Dàqìng
+      Da Qing|Dà Qìng
+      ## Chu Shuzhi 楚恕之 Chǔ shù zhī
+      Chu Shu Zhi|Chǔ Shùzhī
+      ## Wang Zheng 汪徵 Wāng zhēng
+      Wang Zheng|Wāng Zhēng
+      ## Lin Jing 林静 Lín Jìng
+      Lin Jing|Lín Jìng
+      ## Sang Zan 桑赞 Sāng Zàn
+      Sang Zan|Sāng Zàn
+      ## Old Li 老李 lǎo Lǐ Old Lǐ
+      Old Li|Old Lǐ
+      Lao Li|Lǎo Lǐ
+      ## Ye Zun 夜尊 Yè Zūn
+      Ye Zun|Yè Zūn
+      ## Zhu Jiu 烛九 Zhú jiǔ
+      Zhu Jiu|Zhú jiǔ
+      ## Ya Qing 鸦青 Yā Qīng
+      Ya Qing|Yā Qīng
+      ## Sha Ya 沙雅 Shā Yǎ
+      Sha Ya|Shā Yǎ
+      ## Wang Xiangyang 王向阳 Wáng Xiàngyáng
+      Wang Xiang Yang|Wáng Xiàngyáng
+      ## Li Qian 李茜 Lǐ Qiàn
+      Li Qian|Lǐ Qiàn
+      ## Cheng Xinyan 成心妍 Chéng Xīnyán
+      Cheng Xin Yan|Chéng Xīnyán
+      ## Ouyang Zhen 欧阳贞 Ōuyáng Zhēn
+      Ou Yang Zhen|Ōuyáng Zhēn
+      ## Professor Zhou 周教授 Zhōu-jiàoshòu
+      Professor Zhou|Professor Zhōu
+      Teacher Zhou|Teacher Zhōu
+      Zhou Jiao Shou|Zhōu-jiàoshòu
+      ## Wu Tian'en 吴天恩 Wú Tiān'ēn
+      Wu Tian En|Wú Tiān'ēn
+      ## Wu Xiaojun 吴晓君 Wú Xiǎojūn
+      Wu Xiao Jun|Wú Xiǎojūn
+      ## Fourth Uncle 四叔 Sì Shū
+      si shu|Sì Shū
+      ## Ying Chun 迎春 Yíng Chūn
+      Ying Chun|Yíng Chūn
+      ## Cong Bo 丛波 Cóng Bō
+      Cong Bo|Cóng Bō
+      ## Gao Jingfeng 高劲风 Gāo Jìngfēng
+      Gao Jing Feng|Gāo Jìngfēng
+      ## An Bai 安柏 Ān Bǎi
+      An Bai|Ān Bǎi
+      ## Ye Huo 野火 Yě Huǒ
+      Ye Huo|Yě Huǒ
+      ## Da Ji 大吉 Dà Jí
+      Da Ji|Dà Jí
+      ## Bai Suxia 白素霞 Bái Sùxiá
+      Bai Su Xia|Bái Sùxiá
+      ## Shen Xi 沈溪 Shěn Xī
+      Shen Xi|Shěn Xī
+      ## Zhang Shi 獐狮 Zhāng Shī
+      Zhang Shi|Zhāng Shī
+      ## Chu Nianzhi 楚念之 Chǔ Niànzhī
+      Chu Nian Zhi|Chǔ Niànzhī
+      ## Guo Changjiang 郭长江 Guō Chángjiāng
+      Guo Chang Jiang|Guō Chángjiāng
+      ## Guo Xiong 郭雄 Guō Xióng
+      Guo Xiong|Guō Xióng
+      
+      # PLACES
+      ## Dragon City (龙城 Lóng chéng)
+      Long Cheng|Lóng Chéng
+      Long City|Lóng City
+      
+      # TERMS
+      ## Haixing 海星 Hǎixīng
+      Hai Xing|Hǎixīng
+      ## Dixing 地星(人) Dexīngrén
+      Di Xing Ren|Dixīngrén
+      Di Xing|Dixīng
+      Ya Shou|Yàshòu
+      ## Rebel Chieftain 贼酋 zéiqiú
+      Zei Qiu|Zéiqiú
+      ## Regent  摄政官 shèzhènggūan
+      She Zheng Guan|Shèzhènggūan
+      `;
+}
+
+/**
+ * Turn a long replacements string into a list of match objects, where:
+ *  - match.words is an array of strings that form the individual words to match
+ *  - match.replacement is the text to replace that sequence with
+ */
+function splitReplacements(replacements) {
+  return replacements.split('\n')
+      .map(function(line) {
+        return line.trim();
+      })
+      .filter(function(line) {
+        return line.length > 0 && !line.startsWith('#');
+      })
+      .map(function(line) {
+        const match = line.split('|');
+        return {
+          words: match[0].split(' ').filter(match => match.length > 0),
+          replacement: match[1].trim()
+        };
+      });
+}
+
+/**
+ * Checks for pairs of replacements seq1|replacement1 and seq2|replacement2
+ * where seq1|replacement1 comes before seq2|replacement2 in the long list,
+ * and seq1 applies a replacement that might prevent seq2 from matching.
+ *
+ * Example: if 'lan|Lán' is followed by 'Song Lan|Sòng Lán', by the time we try
+ * to replace 'song lan' with 'Sòng Lán', the 'lan' in 'song lan' will already
+ * have been replaced with 'Lán', and so we'd have to be able to match 'song
+ * Lán' in order to replace it with 'Sòng Lán'. This can be fixed by (a)
+ * altering the order of the two replacements, e.g. by putting 'lan|Lán' at the
+ * very end, or by replacing 'Song Lan|Sòng Lán' with 'Song Lán|Sòng Lán' in
+ * order to make sure we still match it after the replacement.
+ */
+function verifyReplacements(allReplacementsString) {
+  const replacements = splitReplacements(allReplacementsString);
+  const replacementsSoFar = [];
+  for (let i = 0; i < replacements.length; i++) {
+    const cur = replacements[i];
+    const potentialMatch = cur.words.join('-');
+    const conflicts = replacementsSoFar.filter(
+        match => potentialMatch.match(
+                     new RegExp(wordsMatchRegex(match.words), 'i')) !== null);
+    if (conflicts.length > 0) {
+      console.log(
+          'May have difficulty matching \'' + potentialMatch + '\' (' +
+          cur.replacement + '):');
+      conflicts.forEach(function(conflict) {
+        console.log(
+            ' - Conflict with \'' + conflict.words.join('-') + '\' (' +
+            conflict.replacement + ')');
+      });
+    }
+    replacementsSoFar.push(cur);
+  }
+}
+
+/**
+ * Use the hard-coded replacement rules string to replace matches with pinyin
+ * in the associated doc.
+ */
+function replaceAll(allReplacementsString) {
+  const body = DocumentApp.getActiveDocument().getBody();
+  const replacements = splitReplacements(allReplacementsString);
+  replacements.forEach(function(element) {
+    body.replaceText(
+        wordsMatchIgnoreCaseRegex(element.words), element.replacement);
+  });
+}
+
+/** Function that runs when users use the mdzs menu option. */
+function mdzs() {
+  // Useful while messing with this script to verify replacement order.
+  // Doesn't actually alter the doc.
+  verifyReplacements(mdzsReplacements());
+  // Replace text in the doc with pinyin!
+  replaceAll(mdzsReplacements());
+}
+
+/** Function that runs when users use the guardian menu option. */
 function guardian() {
-  
-  var body = DocumentApp.getActiveDocument().getBody();
-  
-  //Zhao Yunlan (赵云澜 / 趙云瀾, Zhào Yúnlán)
-  body.replaceText("(C|c)hief.?(Z|z)hao", "Chief Zhào");
-  body.replaceText("(Z|z)hao.?(Y|y)un.?(L|l)an", "Zhào Yúnlán");
-  body.replaceText("(Y|y)un(L|l)an", "Yúnlán");
-  //in the past: Kunlan Kūnlún | 昆仑
-  body.replaceText("(K|k)un(L|l)un", "Kūnlún");
-  
-  
-  //Shen Wei (沈巍	Shěn Wēi) or Xiao Wei Xiǎo Wēi 小巍
-  body.replaceText("(S|s)hen.?(W|w)ei", "Shěn Wēi");
-  body.replaceText("(P|p)rofessor.?(S|s)hen", "Professor Shěn");
-  body.replaceText("(H|h)ei.?(P|p)ao.?(S|s)hi", "Hēi Páo Shǐ");
-  body.replaceText("(X|x)iao.?(W|w)ei", "Xiǎo Wēi")
-  
-  //Zhao Xinci (赵心慈	Zhào Xīncí)
-  body.replaceText("(Z|z)hao.?(X|x)in.?(C|c)i", "Zhào Xīncí");
-  
-  //Guo Ying 郭英 Guō Yīng
-  body.replaceText("(G|g)uo.?(Y|y)ing", "Guō Yīng");
-
-  //Guo Changcheng 郭长城 Guō Chángchéng
-  body.replaceText("(G|g)uo.?(C|c)hang.?(C|c)heng", "Guō Chángchéng");
-
-  //Zhu Hong 祝红 Zhù hóng
-  body.replaceText("(Z|z)hu.?(H|h)ong", "Zhù Hóng");
-
-  //Da Qing 大庆 Dàqìng
-  body.replaceText("(D|d)a.?(Q|q)ing", "Dà Qìng");
-
-  //Chu Shuzhi 楚恕之 Chǔ shù zhī
-  body.replaceText("(C|c)hu.?(S|s)hu.?(Z|z)hi", "Chǔ Shùzhī");
-  
-  //Wang Zheng 汪徵 Wāng zhēng
-  body.replaceText("(W|w)ang.?(Z|z)heng", "Wāng Zhēng");
-
-  //Lin Jing 林静 Lín Jìng
-  body.replaceText("(L|l)in.?(J|j)ing", "Lín Jìng");
-  
-  //Sang Zan 桑赞 Sāng Zàn
-  body.replaceText("(S|s)ang.?(Z|z)an", "Sāng Zàn");
-  
-  //Old Li 老李 lǎo Lǐ Old Lǐ
-  body.replaceText("(O|o)ld.?(L|l)i", "Old Lǐ");
-  body.replaceText("(L|l)ao.?(L|l)i", "Lǎo Lǐ");
-  
-  //Ye Zun 夜尊 Yè Zūn
-  body.replaceText("(Y|y)e.?(Z|z)un", "Yè Zūn");
-  
-  //Zhu Jiu 烛九 Zhú jiǔ
-  body.replaceText("(Z|z)hu.?(J|j)iu", "Zhú jiǔ");
-  
-  //Ya Qing 鸦青 Yā Qīng
-  body.replaceText("(Y|y)a.?(Q|q)ing", "Yā Qīng");
-  
-  //Sha Ya 沙雅 Shā Yǎ
-  body.replaceText("(S|s)ha.?(Y|y)a", "Shā Yǎ");
-  
-  //Wang Xiangyang 王向阳 Wáng Xiàngyáng
-  body.replaceText("(W|w)ang.?(X|x)iang.?(Y|y)ang", "Wáng Xiàngyáng");
-  
-  //Li Qian 李茜 Lǐ Qiàn
-  body.replaceText("(L|l)i.?(Q|q)ian", "Lǐ Qiàn");
-  
-  //Cheng Xinyan 成心妍 Chéng Xīnyán
-  body.replaceText("(C|c)heng.?(X|x)in.?(Y|y)an", "Chéng Xīnyán");
-  
-  //Ouyang Zhen 欧阳贞 Ōuyáng Zhēn
-  body.replaceText("(O|o)u.?(Y|y)ang.?(Z|z)hen", "Ōuyáng Zhēn");
-  
-  //Professor Zhou 周教授 Zhōu-jiàoshòu
-  body.replaceText("(P|p)rofessor.?(Z|z)hou", "Professor Zhōu");
-  body.replaceText("(T|t)eacher.?(Z|z)hou", "Teacher Zhōu");
-  body.replaceText("(Z|z)hou.?(J|j)iao.?(S|s)hou", "Zhōu-jiàoshòu");
-  
-  //Wu Tian'en 吴天恩 Wú Tiān'ēn
-  body.replaceText("(W|w)u.?(T|t)ian.?(E|e)n", "Wú Tiān'ēn");
-  
-  //Wu Xiaojun 吴晓君 Wú Xiǎojūn
-  body.replaceText("(W|w)u.?(X|x)iao.?(J|j)un", "Wú Xiǎojūn");
-  
-  //Fourth Uncle 四叔 Sì Shū
-  body.replaceText("(S|s)ha.?(Y|y)a", "Shā Yǎ");
-
-  //Ying Chun 迎春 Yíng Chūn
-  body.replaceText("(Y|y)ing.?(C|c)hun", "Yíng Chūn");
-  
-  //Cong Bo 丛波 Cóng Bō
-  body.replaceText("(C|c)ong.?(B|b)o", "Cóng Bō");
-
-  //Gao Jingfeng 高劲风 Gāo Jìngfēng
-  body.replaceText("(G|g)ao.?(J|j)ing.?(F|f)eng", "Gāo Jìngfēng");
-  
-  //Guo Ying 郭英 Guō Yīng
-  body.replaceText("(G|g)uo.?(Y|y)ing", "Guō Yīng");
-
-  //An Bai 安柏 Ān Bǎi
-  body.replaceText("(A|a)n.?(B|b)ai", "Ān Bǎi");
-
-  //Ye Huo 野火 Yě Huǒ
-  body.replaceText("(Y|y)e.?(H|h)uo", "Yě Huǒ");
-
-  //Da Ji 大吉 Dà Jí
-  body.replaceText("(D|d)a.?(J|j)i", "Dà Jí");
-  
-  //Bai Suxia 白素霞 Bái Sùxiá
-  body.replaceText("(B|b)ai.?(S|s)u.?(X|x)ia", "Bái Sùxiá");
-
-  //Shen Xi 沈溪 Shěn Xī
-  body.replaceText("(S|s)hen.?(X|x)i", "Shěn Xī");
-
-  //Zhang Shi 獐狮 Zhāng Shī
-  body.replaceText("(Z|z)hang.?(S|s)hi", "Zhāng Shī");
-
-  //Chu Nianzhi 楚念之 Chǔ Niànzhī
-  body.replaceText("(C|c)hu.?(N|n)ian.?(Z|z)hi", "Chǔ Niànzhī");
-
-  //Guo Changjiang 郭长江 Guō Chángjiāng
-  body.replaceText("(G|g)uo.?(C|c)hang.?(J|j)iang", "Guō Chángjiāng");
-
-  //Guo Xiong 郭雄 Guō Xióng
-  body.replaceText("(G|g)uo.?(X|x)iong", "Guō Xióng");
-
-  
-  //
-  //
-  // PLACES
-  //
-  //
-  
-  //Dragon City (龙城 Lóng chéng)
-  body.replaceText("(L|l)ong.?(C|c)heng", "Lóng Chéng");
-  body.replaceText("(L|l)ong.?(C|c)ity", "Lóng City");
-  
-  //
-  //
-  // TERMS
-  //
-  //
-  
-  //Haixing 海星 Hǎixīng
-  body.replaceText("(H|h)ai.?(X|x)ing", "Hǎixīng");
-  
-  //Dixing 地星(人) Dexīngrén
-  body.replaceText("(D|d)i.?(X|x)ing.?(R|r)en", "Dixīngrén");
-  body.replaceText("(D|d)i.?(X|x)ing", "Dixīng");
-  
-  body.replaceText("(Y|y)a.?(S|s)hou", "Yàshòu");
-  
-  //Rebel Chieftain 贼酋 zéiqiú
-  body.replaceText("(Z|z)ei.?(Q|q)iu", "Zéiqiú");
-  
-  //Regent  摄政官 shèzhènggūan
-  body.replaceText("(S|s)he.?(Z|z)heng.?(G|g)uan", "Shèzhènggūan");
-  
+  // Useful while messing with this script to verify replacement order.
+  // Doesn't actually alter the doc.
+  verifyReplacements(guardianReplacements());
+  // Replace text in the doc with pinyin!
+  replaceAll(guardianReplacements());
 }


### PR DESCRIPTION
At first I was trying to get pinyinScript.txt to the point where it could be directly deployed as a docs add-on, but I couldn't actually figure that part out (it maybe requires some sort of google cloud project thing? anyway I gave up). But I did a lot of messing with it first before I did that investigation, and I think some of the refactoring might still make it easier for non-regex-experts to potentially contribute replacement rules, either for an existing or new fandom. Maybe there'll be a voiceteam challenge we can get volunteers from?

As a side note, the new replacements are mostly in the same order (thanks github for totally failing at matching), but I can't swear I didn't make mistakes. And I know that really we mostly want case insensitivity at (Chinese) character boundaries, but I figured restricting matches to full words (with optional spacers) would get us close enough, since *usually* pinyin boundaries are not ambiguous.

Let me know if you want me to try to do a more thorough proof-read/comparison of how matching differs between the previous and current version