### PR TITLE
Add Nirvana in Fire replacements

### DIFF
--- a/google/docs/pinyinScript.txt
+++ b/google/docs/pinyinScript.txt
@@ -17,6 +17,32 @@ function onOpen() {
 }
 
 /**
+ *
+ * @param body
+ * @param pattern
+ * @param newString Replacement for the pattern
+ * @param underline Whether to underline the replacement. Can be useful when
+ * trying to understand what the script is doing.
+ */
+function replaceWithUnderline(body, pattern, newString, underline) {
+  if (underline) {
+    var found = body.findText(pattern);
+    while (found) {
+      var elem = found.getElement();
+      if (found.isPartial()) {
+        var start = found.getStartOffset();
+        var end = found.getEndOffsetInclusive();
+        elem.setUnderline(start, end, true);
+      } else {
+        elem.setUnderline(true);
+      }
+      found = body.findText(pattern, found);
+    }
+  }
+  body.replaceText(pattern, newString);
+}
+
+/**
  * Returns a regex string to match a sequence of words, allowing an optional
  * dash (-) or space ( ) between each word. The beginning and end of the
  * matching sequence must be at a word boundary.
@@ -835,12 +861,13 @@ function verifyReplacements(allReplacementsString) {
  * Use the hard-coded replacement rules string to replace matches with pinyin
  * in the associated doc.
  */
-function replaceAll(allReplacementsString) {
+function replaceAll(allReplacementsString, underline) {
   const body = DocumentApp.getActiveDocument().getBody();
   const replacements = splitReplacements(allReplacementsString);
   replacements.forEach(function(element) {
-    body.replaceText(
-        wordsMatchIgnoreCaseRegex(element.words), element.replacement);
+    replaceWithUnderline(
+        body, wordsMatchIgnoreCaseRegex(element.words), element.replacement,
+        underline);
   });
 }
 
@@ -850,7 +877,7 @@ function mdzs() {
   // Doesn't actually alter the doc.
   verifyReplacements(mdzsReplacements());
   // Replace text in the doc with pinyin!
-  replaceAll(mdzsReplacements());
+  replaceAll(mdzsReplacements(), false);
 }
 
 /** Function that runs when users use the guardian menu option. */
@@ -859,7 +886,7 @@ function guardian() {
   // Doesn't actually alter the doc.
   verifyReplacements(guardianReplacements());
   // Replace text in the doc with pinyin!
-  replaceAll(guardianReplacements());
+  replaceAll(guardianReplacements(), false);
 }
 
 /** Function that runs when users use the nirvana in fire menu option. */
@@ -868,5 +895,5 @@ function nirvana() {
   // Doesn't actually alter the doc.
   verifyReplacements(nirvanaReplacements());
   // Replace text in the doc with pinyin!
-  replaceAll(nirvanaReplacements());
+  replaceAll(nirvanaReplacements(), false);
 }

--- a/google/docs/pinyinScript.txt
+++ b/google/docs/pinyinScript.txt
@@ -12,6 +12,7 @@ function onOpen() {
   ui.createMenu('Pinyin')
       .addItem('mdzs', 'mdzs')
       .addItem('guardian', 'guardian')
+      .addItem('nirvana in fire', 'nirvana')
       .addToUi();
 }
 
@@ -409,6 +410,370 @@ function guardianReplacements() {
 }
 
 /**
+ * Hard-coded Nirvana in Fire pinyin replacement rules.
+ */
+function nirvanaReplacements() {
+  // For each line 'some text here|fancy replacement', replaces all instances of
+  // 'some text here' in the doc with 'fancy replacement'.
+  // Notes:
+  //  * capitalization on the left side is ignored
+  //  * any spaces on the left side that are between words will matching things
+  //    with
+  //    (a) no space there (b) a dash there or (c) a space there. Examples:
+  //      - 'hanguang jun|Hánguāng-jūn' means any of 'hanguang jun',
+  //        'hanguangjun', or 'hanguang-jun' will be replaced with
+  //        'Hánguāng-jūn'
+  //      - 'wen ke xing|Wēn Kèxíng' means that all of 'Wen KeXing', 'Wen Ke
+  //        Xing', and 'wen kexing' will be replaced with 'Wēn Kèxíng'
+  //  * any spaces on the left or right that are before all words or after all
+  //    words will be ignored
+  //  * partial-word matches will be ignored (e.g., if 'lan' is part of 'plan'
+  //    or 'land' it will not be replaced; if 'lan sect' is part of 'plan sect'
+  //    it will not be replaced)
+  //  * lines with only spaces on them, or that start with #, will be ignored.
+  return `
+      # Mostly from: https://lunatique.dreamwidth.org/221558.html
+      ## I (irrationalpie) changed some capitalization and spacing?
+      ## But I was just guessing
+
+      # Láng Yá Băng  琅琊榜
+      lang ya bang|Láng Yá Băng
+
+      # Part 1 - Main Cast (MCS, NH, JY, LC)
+      ## Méi Cháng Sū 梅长苏
+      mei chang su|Méi Chángsū
+      chang su|Chángsū
+      ## Sū Zhé 苏哲
+      su zhe|Sū Zhé
+      ## Lín Shū 林殊
+      lin shu|Lín Shū
+      ## xiăo-Shū 小殊
+      xiao shu|xiăo-Shū
+      ## Zōng zhŭ 宗主 (Chief)
+      zong zhu|Zōngzhŭ
+      ## Sū xiānsheng 苏先生 (Sir Su)
+      su xian sheng|Sū xiānsheng
+      sir su|Sir Sū
+      su manor|Sū Manor
+      ## Sū gēge 苏哥哥 (big brother)
+      su gege|Sū gēge
+      ## Mù Ní Huáng 穆霓凰
+      ## Ní Huáng jiějie  霓凰姐姐 (big sister)
+      mu ni huang|Mù Níhuáng
+      ni huang|Níhuáng
+      mu manor|Mù Manor
+      ## Ní Huáng Jùn Zhŭ  霓凰郡主 (Princess/Duchess)
+      ## idk if this title can go alone, but here's my attempt
+      ## at capitalization
+      Níhuáng jun zhu|Níhuáng jùnzhŭ
+      jun zhu|Jùnzhŭ
+      ## Xiāo Jĭng Yán 萧景琰
+      xiao jing yan|Xiāo Jĭngyán
+      jing yan|Jĭngyán
+      ## Jìng wáng 靖王 (Prince Jing)
+      jing wang|Jìng wáng
+      prince jing|Prince Jìng
+      jing manor|Jìng Manor
+      ## Diàn xià 殿下 (your highness)
+      dian xia|Diànxià
+      ## Shŭi Niú 水牛 (water buffalo)
+      shui niu|Shŭiniú
+
+      # Lìn Chén 蔺晨 / Lìn Chén gēge 蔺晨哥哥 (big brother)
+      lin chen ge ge|Lìn Chén gēge
+      lin chen|Lìn Chén
+      ## Shào Gé Zhŭ 少阁主(Young Master)
+      ## ¯\_(ツ)_/¯ no idea on spacing/caps
+      shao ge zhu|Shào Gézhŭ
+
+      # Part 2 - Jiang Zuo Alliance (FL,LG,ZP,GY,TL,MiaoYin,Mr13,PhysYan)
+      ## Jiāng Zuŏ Méng 江左盟 (Jiang Zuo Alliance)
+      jiang zuo meng|Jiāngzuŏ Méng
+      jiang zuo|Jiāngzuŏ
+      ## Fēi Liú 飞流
+      Fei Liu|Fēi Liú
+      ## Lí Gāng 黎纲
+      li gang|Lí Gāng
+      ## Zhēn Píng 甄平
+      zhen ping|Zhēn Píng
+      ## Gōng Yŭ 宫羽 (I think I also heard her called guniang/姑娘?)
+      gong yu|Gōng Yŭ
+      gong gu niang|Gōng gūniang
+      ## Wèi Zhēng 卫峥
+      wei zheng|Wèi Zhēng
+      ## Tóng Lù 童路
+      tong lu|Tóng Lù
+      ## Shísān xiānsheng 十三先生(Mr. Shisan)
+      shi san xian sheng|Shísān xiānsheng
+      ## Yàn dàifu  晏大夫(Physician Yan)
+      yan daifu|Yàn dàifu
+
+      # Part 3 - Households (MQ,LX,JinYang,NF,LZY,QM,TS,Foya,etc)
+      ## Chìyàn Jūn 赤焰军 (Chìyàn army)
+      chiyan jun|Chìyàn Jūn
+      chiyan|Chìyàn
+      ## Cháng Lín Jūn 长林军 (Cháng Lín army)
+      changlin jun|Chánglín Jūn
+      changlin|Chánglín
+
+      # Mù Qīng  穆青 / Qīng-er 青儿
+      mu qing|Mù Qīng
+      qing er|Qīng-er
+      ## General Lín Xiè 林燮 / fù shuài 父帅 (father-general)
+      lin zie|Lín Xiè
+      fu shuai|fùshuài
+      ## Jìn Yáng 晋阳 (Grand Princess Jin Yang) (lin shu's mother)
+      jin yang|Jìnyáng
+      ## lin manor, lin family
+      lin manor|Lín Manor
+      lin family|Lín family
+      ## Niè Fēng 聂锋 / Niè dage 聂大哥
+      nie feng|Niè Fēng
+      nie dage|Niè dàgē
+      ## Niè Duó 聂铎
+      nie duo|Niè Duó
+
+      # Liè Zhàn Yīng 列战英
+      lie zhan ying|Liè Zhànyīng
+      zhan ying|Zhànyīng
+      ## Qī Mĕng 戚猛
+      qi meng|Qī Mĕng
+      ## Xiāo Tíng Shēng 萧庭生
+      xiao ting sheng|Xiāo Tíngshēng
+      ting sheng|Tíngshēng
+      ## Fóyá 佛牙
+      fo ya|Fóyá
+
+      # Part 4 - Royal Palace (dadperor, JYu,JH,CP,Jingmom,consorts)
+      ## Liáng Royal Family
+      ## Xiāo Xuǎn 萧选 / Bì Xià 陛下 (your majesty) aka dadperor
+      xiao xuan|Xiāo Xuǎn
+      bi xia|Bìxià
+      ## Xiāo Jĭng Yŭ, 萧景禹 / Prince Qí 祁王 aka whalebro
+      xiao jing yu|Xiāo Jĭngyŭ
+      jing yu|Jĭngyŭ
+      qi wang|Qí wáng
+      prince qi|Prince Qí
+      ## Xiāo Jĭng Huán萧景桓 / Prince Yù  誉王
+      xiao jing huan|Xiāo Jĭnghuán
+      jing huan|Jĭnghuán
+      yu wang|Yù wáng
+      prince yu|Prince Yù
+      yu manor|Yù Manor
+      ## Xiāo Jĭng Xuān 萧景宣 / Prince Xiàn / 太子 Tài Zĭ (crown prince)
+      xiao jing xuan|Xiāo Jĭngxuān
+      jing xuan|Jĭngxuān
+      xian wang|Xiàn wáng
+      prince xian|Prince Xiàn
+      tai zi|Tàizĭ
+      ## Jì wáng 纪王 (Prince Jì)
+      ji wang|Jì wáng
+      prince ji|Prince Jì
+      ## Princess Jĭng Níng 景宁
+      jing ning|Jĭngníng
+
+      # Tàinăinai 太奶奶 (Great-grandmother)
+      tai nai nai|Tàinăinai
+      ## Jìng fēi 静妃 (Consort Jing)
+      jing fei|Jìng fēi
+      consort jing|Consort Jìng
+      concubine jing|Concubine Jìng
+      ## Lì Yáng 莅阳 (Grand Princess Liyang)
+      li yang|Lìyáng
+      ## Yán hòu 言后 (Empress Yan)
+      ## (conflicts with Marquis Yán (Yán hóuyé 言侯爷), so move to the end)
+      ### yan hou|Yán hòu
+      ## Yuè gùi fēi 越贵妃 (Noble Consort Yue)
+      yue gui fei|Yuè gùifēi
+      consort yue|Consort Yuè
+      concubine yue|Concubine Yuè
+      ## Hùi fēi 惠妃 (Consort Hui)
+      hui fei|Hùi fēi
+      consort hui|Consort Hùi
+      concubine hui|Concubine Hùi
+      ## Chén fēi 陈妃 (Consort Chen) / Lín Yùeyáo 林乐瑶
+      chen fei|Chén fēi
+      consort chen|Consort Chén
+      concubine chen|Concubine Chén
+      lin yueyao|Lín Yùeyáo
+      yueyao|Yùeyáo
+      ## niáng niang 娘娘 (madam?)
+      niang niang|niángniang
+
+      # Part 5 - Palace adjacent & Nobles (MZ,GZ,SZ,CQ,JR,YJ,YQ,XY,XB,XQ,Zhuo fam)
+      ## Méng Zhì 蒙挚/ Méng dàgē 蒙大哥
+      meng zhi|Méng Zhì
+      meng da ge|Méng dàgē
+      ## 大统领 dàtǒnglǐng
+      ## --> I *think* these are the chars/pinyin for Méng Zhì's title as commander?
+      meng da tong ling|Méng dàtǒnglǐng
+      ## Gāo Zhàn 高湛 / Gāo gōng-gong 高公公
+      gao zhan|Gāo Zhàn
+      gao gong gong|Gāo gōnggong
+      ## Shĕn Zhūi 沈追 /Shĕn dà ren 沈大人 (minister Shen)
+      shen zhui|Shĕn Zhūi
+      shen da ren|Shĕn dàren
+      ## Cài Quán 蔡荃 / Cài dà ren 蔡大人 (minister Cai)
+      cai quan|Cài Quán
+      cai da ren|Cài dàren
+
+      # Nobles
+      ## Yán Yù Jīn言豫津
+      yan yu jin|Yán Yùjīn
+      yu jin|Yùjīn
+
+      # Marquis Yán Qùe 言阙- Yán hóuyé 言侯爷
+      yan que|Yán Qùe
+      yan hou ye|Yán hóuyé
+      hou ye|hóuyé
+      ## Xiāo Jǐng Ruì 萧景睿
+      xiao jing rui|Xiāo Jǐngruì
+      jing rui|Jǐngruì
+      ## Marquis Xiè Yù 谢玉  / Níng Guó Hóu 宁国侯 (Marquis of Ning)
+      xie yu|Xiè Yù
+      ning guo hou|Níng guóhóu
+      marquis of ning|Marquis of Níng
+      xie manor|Xiè Manor
+      ## Xiè Bì 谢弼
+      xie bi|Xiè Bì
+      ## Xiè Qí 谢绮
+      xie qi|Xiè Qí
+      ## Yŭ Wén Niàn 宇文念
+      yu wen nian|Yŭwén Niàn
+      ## Prince Yŭ Wén Xuān 宇文暄
+      yu wen xuan|Yŭwén Xuān
+      ## Yŭ Wén Lín 宇文霖
+      yu wen lin|Yŭwén Lín
+
+      # Tiān Quán Shān Zhuāng 天泉山庄 (Tian Quan Manor)
+      tian quan shan zhuang|Tiān Quán Shānzhuāng
+      tian quan|Tiān Quán
+      ## Zhuó Dĭngfēng 卓鼎风
+      zhuo ding feng|Zhuó Dĭngfēng
+      ## Zhuó fū ren Madam Zhuó  卓夫人
+      zhuo fu ren|Zhuó fūren
+      madam zhuo|Madam Zhuó
+      ## Zhuó Qīng Yáo 卓青遥
+      zhuo qing yao|Zhuó Qīngyáo
+
+      # Part 6 - Others (XJ,XD,XC,XQ,Banruo,Hua ladies, Locations)
+      # Xuán Jìng Sī 悬镜司 (Xuan Jing Bureau)
+      xuan jing si|Xuánjìng Sī
+      xuan jing|Xuánjìng
+      ## Xià Jiāng 夏江
+      xia jiang|Xià Jiāng
+      ## Xià Dōng 夏冬/Dōng jiě 冬姐
+      xia dong|Xià Dōng
+      dong jie|Dōng jiě
+      ## Xià Chūn 夏春
+      xia chun|Xià Chūn
+      ## Xià Qiū 夏秋
+      xia qiu|Xià Qiū
+      ## Bonus: The Legend of XiaXia
+      xia xia|Xià Xià
+
+      # the Huá
+      ## Huá Zú 滑族 (Zú is race/nationality)
+      hua zu|Huá Zú
+      hua|Huá
+      ## Qín Bān Ruò 秦般若
+      qin ban ruo|Qín Bānruò
+      ban ruo|Bānruò
+      ## Sì Jiĕ 四姐 (4th sister) /  Jùn Niáng 隽娘
+      si jie|Sì Jiĕ
+      jun niang|Jùn Niáng
+      ## Princess Xuán Jī 璇玑公主 (Xuánjī gōngzhǔ)
+      princess xuan ji|Princess Xuánjī
+      xuan ji gong zhu|Xuánjī gōngzhǔ
+      xuan ji|Xuánjī
+      ## Princess Líng Lóng 玲珑公主
+      princess ling long|Princess Línglóng
+      ling long gong zhu|Línglóng gōngzhǔ
+      ling long|Línglóng
+      gong zhu|Gōngzhǔ
+
+      # Locations:
+      ## Méi Lĭng 梅岭 / Mei Cliff
+      mei ling|Méilĭng
+      ## Láng Yá Gé 琅琊阁(Lang Ya Hall) / Láng Yá Shān 琅琊山 (Lang ya Mountain)
+      lang ya ge|Lángyá Gé
+      lang ya shan|Lángyá Shān
+      lang ya|Lángyá
+      ## Láng Zhōu
+      lang zhou|Láng Zhōu
+      ## Dà Liáng 大梁
+      da liang|Dà Liáng
+      ## Jīn Líng 金陵
+      jin ling|Jīnlíng
+      ## Xuĕ Lú 雪庐
+      xue lu|Xuĕ Lú
+      ## Miào Yīn Fáng 妙音坊 (Miao Yin Court)
+      miao yin fang|Miàoyīn Fáng
+      miao yin|Miàoyīn
+      ## Hóng Xiù Zhāo  红袖招
+      hong xiu zhao|Hóng Xiù Zhāo
+      ## Luó Shì Jiē 螺市街 (Luóshì street)
+      luo shi jie|Luóshì Jiē
+      luo shi|Luóshì
+      ## Zhĭ Luó Gōng 芷萝宫 (zhiluo palace)
+      zhi luo gong|Zhĭluó Gōng
+      zhi luo palace|Zhĭluó Palace
+      ## Jiǔān Shān 九安山 (Jiǔān mountain--where the hunting palace was)
+      jiu an shan|Jiǔān Shān
+      jiu an|Jiǔān
+      ## Yào Wáng Gǔ 药王谷 (Yàowáng Valley)
+      yao wang gu|Yàowáng Gǔ
+      yao wang valley|Yàowáng Valley
+      ## Yún Nán 云南 (province mu nihuang is from)
+      yun nan|Yúnnán
+      ## Dōng Hăi 东海 (East China Sea?)
+      dong hai|Dōng Hăi
+      ## Nán Chŭ 南楚 / Southern Chŭ (country that borders yunnan)
+      nan chu|Nán Chŭ
+      southern chu|Southern Chŭ
+      ## Dà Yú 大渝
+      da yu|Dà Yú
+      ## Bĕi Yàn 北燕
+      bei yan|Bĕi Yàn
+      ## Yè Qín
+      ye quin|Yè Qín
+      ## Jiāng Hú 江湖
+      jiang hu|Jiānghú
+
+      # A few misc partial names and titles to try to catch partial matches
+      ## Lín Shū 林殊 / Lìn Chén 蔺晨
+      lin|[Lín (Shū) or Lìn (Chén)]
+      shu|Shū
+      chen|Chén
+      ## Méi Cháng Sū 梅长苏
+      mei|Méi
+      ## Cài Quán 蔡荃 / Cài dà ren 蔡大人 (minister Cai)
+      da ren|dàren
+      ## Gāo Zhàn 高湛 / Gāo gōng-gong 高公公
+      gong gong|gōnggong
+      ## Yuè gùi fēi 越贵妃 (Noble Consort Yue)
+      gui fei|gùifēi
+      ## Fēi Liú 飞流 and consort (妃) are both "fēi" so we cheat a little here
+      fei|Fēi
+      ## Zhuó fū ren Madam Zhuó  卓夫人
+      fu ren|fūren
+      ## I *think* guniang is this --> 姑娘?
+      gu niang|gūniang
+      ## sibling relations
+      da ge|dàgē
+      ge ge|gēge
+      ge|gē
+      jie jie|jiějie
+      jie|jiě
+
+      # Conflicts:
+      ## Yán hòu 言后 (Empress Yan)
+      ## (conflicts with Marquis Yán (Yán hóuyé 言侯爷), so move to the end)
+      yan hou|Yán hòu
+      `;
+}
+
+/**
  * Turn a long replacements string into a list of match objects, where:
  *  - match.words is an array of strings that form the individual words to match
  *  - match.replacement is the text to replace that sequence with
@@ -495,4 +860,13 @@ function guardian() {
   verifyReplacements(guardianReplacements());
   // Replace text in the doc with pinyin!
   replaceAll(guardianReplacements());
+}
+
+/** Function that runs when users use the nirvana in fire menu option. */
+function nirvana() {
+  // Useful while messing with this script to verify replacement order.
+  // Doesn't actually alter the doc.
+  verifyReplacements(nirvanaReplacements());
+  // Replace text in the doc with pinyin!
+  replaceAll(nirvanaReplacements());
 }


### PR DESCRIPTION
Adds replacement rules for Nirvana in Fire based mostly on [lunatique's Nirvana in Fire guide](https://lunatique.dreamwidth.org/221558.html), although I made some spacing and capitalization changes based on how I've mostly seen words grouped in fanfic, using the [Nirvana in Fire wiki](https://nirvanainfire.fandom.com/wiki/Nirvana_in_Fire_Wiki) for help with that. Hopefully it turned out okay?

This pull request also includes a commit to enable underlining replacements. I used it for testing the behavior of the new additions, but it's currently turned off because I wasn't sure about making such a change in functionality. It's the `false` on the `replaceAll(<fandom>Replacements(), false);` lines that turns it off--you can view the other behavior by changing that to `true` before running any of the replacement functions.